### PR TITLE
Add initial automated benchmark run

### DIFF
--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -13,8 +13,9 @@ on:
         required: false
         default: 'main'
 
+# Ensure we can push changes back
 permissions:
-  contents: write  # 👈 Required to push code
+  contents: write
 
 # Ensure only one instance of the workflow is running at a time
 concurrency:
@@ -23,7 +24,7 @@ concurrency:
 jobs:
   run-benchmarks:
     runs-on: ucc-benchmarks-8-core-U22.04
-    # DO not run benchmarks on commits that were themselves benchmark results
+    # DO not run benchmarks on forks, or on commits that were themselves benchmark results
     if: ${{ github.repository == 'unitaryfoundation/ucc-bench' && !contains(github.event.head_commit.message, '[benchmark chore]') }}
 
     steps:
@@ -42,6 +43,7 @@ jobs:
         - name: Install the project
           run: uv sync --all-extras --dev
 
+        # Run the benchmarks for the commit that triggered this workflow
         - name: Run benchmarks
           run: ./scripts/run_benchmarks.sh ${{ github.sha }} ${{ runner.name }} ./results
 
@@ -58,10 +60,11 @@ jobs:
           env:
             SHORT_SHA: ${{ github.sha }}
           run: |
-            git add results/*
+            git add ./results/*
             git diff-index --quiet HEAD || git commit -m "[benchmark chore] Update benchmark results for ${{ github.repository }}@${SHORT_SHA:0:7}"
 
         # Do a quick pull with rebase to ensure we are up to date with the main branch
+        # for example if another commit was pushed to main while this workflow was running
         - name: Pull with rebase
           run: |
             git pull --rebase origin main

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -1,0 +1,74 @@
+# This workflows runs and commits the standard benchmark results.
+# This workflow will install Python dependencies, run benchmarks and then publish the results to github
+name: Run Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run benchmarks on'
+        required: false
+        default: 'main'
+
+permissions:
+  contents: write  # 👈 Required to push code
+
+# Ensure only one instance of the workflow is running at a time
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  run-benchmarks:
+    runs-on: ucc-benchmarks-8-core-U22.04
+    # DO not run benchmarks on commits that were themselves benchmark results
+    if: ${{ github.repository == 'unitaryfoundation/ucc-bench' && !contains(github.event.head_commit.message, '[benchmark chore]') }}
+
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            persist-credentials: false
+
+        - name: Install uv
+          uses: astral-sh/setup-uv@v5
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+            python-version-file: ".python-version"
+
+        - name: Install the project
+          run: uv sync --all-extras --dev
+
+        - name: Run benchmarks
+          run: ./scripts/run_benchmarks.sh ${{ github.sha }} ${{ runner.name }}
+
+        # Configure git to use the name/email of github-actions[bot] so it renders
+        # as a bot commit in the GitHub UI
+        - name: Configure Git
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # diff-index only succeeds if there are changes to commit
+        # use truncated sha in commit message
+        - name: Commit changes
+          env:
+            SHORT_SHA: ${{ github.sha }}
+          run: |
+            git add results/*
+            git diff-index --quiet HEAD || git commit -m "[benchmark chore] Update benchmark results for ${{ github.repository }}@${SHORT_SHA:0:7}"
+
+        # Do a quick pull with rebase to ensure we are up to date with the main branch
+        - name: Pull with rebase
+          run: |
+            git pull --rebase origin main
+
+        - name: Push changes
+          env:
+            TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            git push https://x-access-token:${TOKEN}@github.com/${{ github.repository }} HEAD:main
+

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -43,7 +43,7 @@ jobs:
           run: uv sync --all-extras --dev
 
         - name: Run benchmarks
-          run: ./scripts/run_benchmarks.sh ${{ github.sha }} ${{ runner.name }}
+          run: ./scripts/run_benchmarks.sh ${{ github.sha }} ${{ runner.name }} ./results
 
         # Configure git to use the name/email of github-actions[bot] so it renders
         # as a bot commit in the GitHub UI

--- a/.github/workflows/run_benchmarks.yml
+++ b/.github/workflows/run_benchmarks.yml
@@ -1,5 +1,7 @@
 # This workflows runs and commits the standard benchmark results.
-# This workflow will install Python dependencies, run benchmarks and then publish the results to github
+# Runs automatically on pushes to the main branch (e.g. after a pull request is merged).
+# If triggered manually, runs on the latest commit of that branch, and pushes results back to
+# that branch.
 name: Run Benchmarks
 
 on:
@@ -7,71 +9,58 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to run benchmarks on'
-        required: false
-        default: 'main'
 
-# Ensure we can push changes back
 permissions:
   contents: write
 
-# Ensure only one instance of the workflow is running at a time
 concurrency:
   group: ${{ github.workflow }}
 
 jobs:
   run-benchmarks:
     runs-on: ucc-benchmarks-8-core-U22.04
-    # DO not run benchmarks on forks, or on commits that were themselves benchmark results
+
+    # Don't run on forks or on commits that are already benchmark results
     if: ${{ github.repository == 'unitaryfoundation/ucc-bench' && !contains(github.event.head_commit.message, '[benchmark chore]') }}
 
     steps:
-        - uses: actions/checkout@v4
-          with:
-            persist-credentials: false
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
-        - name: Install uv
-          uses: astral-sh/setup-uv@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-        - name: Set up Python
-          uses: actions/setup-python@v5
-          with:
-            python-version-file: ".python-version"
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
 
-        - name: Install the project
-          run: uv sync --all-extras --dev
+      - name: Install the project
+        run: uv sync --all-extras --dev
 
-        # Run the benchmarks for the commit that triggered this workflow
-        - name: Run benchmarks
-          run: ./scripts/run_benchmarks.sh ${{ github.sha }} ${{ runner.name }} ./results
+      - name: Run benchmarks
+        run: ./scripts/run_benchmarks.sh ${{ github.sha }} ${{ runner.name }} ./results
 
-        # Configure git to use the name/email of github-actions[bot] so it renders
-        # as a bot commit in the GitHub UI
-        - name: Configure Git
-          run: |
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-        # diff-index only succeeds if there are changes to commit
-        # use truncated sha in commit message
-        - name: Commit changes
-          env:
-            SHORT_SHA: ${{ github.sha }}
-          run: |
-            git add ./results/*
-            git diff-index --quiet HEAD || git commit -m "[benchmark chore] Update benchmark results for ${{ github.repository }}@${SHORT_SHA:0:7}"
+      - name: Commit changes
+        env:
+          SHORT_SHA: ${{ github.sha }}
+        run: |
+          git add ./results/*
+          git diff-index --quiet HEAD || git commit -m "[benchmark chore] Update benchmark results for ${{ github.repository }}@${SHORT_SHA:0:7}"
 
-        # Do a quick pull with rebase to ensure we are up to date with the main branch
-        # for example if another commit was pushed to main while this workflow was running
-        - name: Pull with rebase
-          run: |
-            git pull --rebase origin main
+      - name: Pull with rebase
+        run: |
+          git pull --rebase origin ${{ github.ref_name }}
 
-        - name: Push changes
-          env:
-            TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          run: |
-            git push https://x-access-token:${TOKEN}@github.com/${{ github.repository }} HEAD:main
-
+      - name: Push changes
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push https://x-access-token:${TOKEN}@github.com/${{ github.repository }} HEAD:${{ github.ref_name }}

--- a/TODO
+++ b/TODO
@@ -81,3 +81,74 @@ hash (commit on main)-> compiler versions, benchmark configs, etc.
 ucc PR <> ok if fails
 only have ucc hash/versions, how do I lookup my ancestor PR
   -> secondary index? ucc version hash -> version of ucc-bench with those results
+
+---------------------------------------------
+ucc-bench after merge to main with tip hash H
+Trigger - commit to main that is not chore
+No cancelling, always run
+//
+1. Checkout code @ H
+2. Run both types of benchmarks (using uid of that H and that hash time)
+3. Store results
+5. Commit back to repo as a bench(H)
+----------------------------------------------
+update plots every X hours
+trigger - cron
+No cancelling, always run
+1. Checkout tip of ucc-bench
+2. Generate plots from most recent hash (ignoring the chore commits)
+----------------------------------------------
+ucc-merge to main with tip hash H -> open a ucc-bench PR to main
+Trigger - ucc-merge to main (for now, non chore/benchark commits)
+No cancelling, always run, but only run for that final commit, not all commits along the way
+//
+1. ucc-bench checkout tip of main
+2. uv upgrades to ucc to version H on branch auto-benchmark-H
+3. create commit, include ucc-bench H in commit message
+4. set commit to auto-merge if checks are successful
+-----------------------------------------------
+PR on open ucc-bench PR to main
+Trigger - PR open, PR updated (change to commits)
+Cancel existing job if retriggered for same PR
+//
+1. IF is auto-benchmark/labeled (so was already benchmarked), just add a comment with link to ucc PR
+2. If is not, then
+   - Checkout code
+   - Run benchmarks
+   - Do a diff against benchmark results for ancestor on main
+     - Note this is the most recent NON-chore commit to main, e.g. a commit that
+       reflects a true change.
+     - If none exists, bail
+   - Add comment
+------------------------------------------------
+PR on ucc to main
+Trigger - PR open, PR updated (change to commits) in *ucc*
+Cancel existing job if retriggered for same PR
+//
+1. Checkout ucc-bench code
+2. Upgrade to the tip commit of ucc branch/hash
+3. run benchmarks
+4. Compare to common ancestor results on ucc main branch
+    Should be the ucc-bench commit that wasn't a chore
+    How do we find this??? Do we store in bench(foo,bar)?
+    Do we add a mapping file/metadata to the ucc-bench run, if it was triggered
+    by ucc commit? (Yes, seems better)
+
+Failure modes
+1. PR comparison breaks, annoying but can live with it
+2. ucc -> ucc-bench trigger breaks, annoying, but can manually kick them off
+3. ucc-bench -> out of order results,  impactes
+              REVIEW - plots by time --- any other data to re-order? use ucc git commit date, when subset on just UCC data
+                  Use auxiliary ucc uid date/hash to order the UCC results, and use other date for non-ucc results
+                  Make this explicit (annoying but ok)
+              "most recent ancestor" in PR diff (ok, just ignore if can't explicitly find)
+
+ucc-benchmark results aren't necessarily time ordered (e.g. multiple commits come in)
+Always make the plots for latest/over-time time ordered based on what is in the queue?
+
+So
+1. Add auxiliary data to simulation results, command line to specify
+2. Build github actions in order above (ucc-bench, trigger ucc-bench, cron for plots, PRs)
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,5 +29,8 @@ dev = [
     "pytest>=8.3.5",
     "ruff>=0.11.2",
 ]
+
+[tool.uv.sources]
+ucc = { git = "https://github.com/unitaryfoundation/ucc", rev = "65e6bdbfd1f30a015375e58c40b359d4a816ba5d" }
 [project.scripts]
 ucc-bench = 'ucc_bench.main:main'

--- a/scripts/extract_ucc_revision.py
+++ b/scripts/extract_ucc_revision.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import sys
+import tomllib  # For parsing TOML files (Python 3.11+)
+
+
+def extract_ucc_revision(file_path):
+    try:
+        with open(file_path, "rb") as f:
+            data = tomllib.load(f)
+
+        # Navigate to the tool.uv.sources section
+        uv_sources = data.get("tool", {}).get("uv", {}).get("sources", {})
+        if "ucc" not in uv_sources:
+            print("Error: 'ucc' entry not found in 'tool.uv.sources'.", file=sys.stderr)
+            sys.exit(1)
+
+        # Extract the revision hash
+        ucc_entry = uv_sources["ucc"]
+        revision = ucc_entry.get("rev")
+        if not revision:
+            print("Error: 'rev' key is missing in 'ucc' entry.", file=sys.stderr)
+            sys.exit(1)
+
+        print(revision)
+    except FileNotFoundError:
+        print(f"Error: File '{file_path}' not found.", file=sys.stderr)
+        sys.exit(1)
+    except tomllib.TOMLDecodeError:
+        print(f"Error: Failed to parse TOML file '{file_path}'.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(
+            "Usage: python extract_ucc_revision.py <path_to_pyproject.toml>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    extract_ucc_revision(file_path)

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Ensure this script is run from the root of the repository
+if [ ! -f "scripts/run_benchmarks.sh" ]; then
+  echo "Please run this script from the root of the repository."
+  exit 1
+fi
+# The first argument to the script is the commit hash
+if [ -z "$1" ]; then
+  echo "Usage: $0 <commit-hash>"
+  exit 1
+fi
+commit_hash=$1
+
+# The second argument to the script is the runner name
+if [ -z "$2" ]; then
+  echo "Usage: $0 <commit-hash> <runner-name>"
+  exit 1
+fi
+runner_name=$2
+
+# Get timestamp of the commit (in UTC)
+uid_time=$(TZ=UTC git show -s --format=%cI <commit_hash>)
+
+# Figure out the current hash of ucc that is used in this repo by parsing pyproject.toml
+ucc_hash=$(grep -oP '(?<=ucc = ").*(?=")' pyproject.toml)
+# Use the github API to get the commit date of the ucc hash
+ucc_commit_date=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/unitaryfoundation/ucc/commits/${ucc_hash}" | jq -r '.[0].commit.committer.date')
+
+uv run ucc-bench ./benchmarks/timing_benchmarks.toml --uid '${commit_hash}' --uid_time '${uid_time}' --log_level INFO -o ./results --runner_name '${runner_name}'
+uv run ucc-bench ./benchmarks/simulation_benchmarks.toml --uid '${commit_hash}' --uid_time '${uid_time}' --log_level INFO -o ./results --runner_name '${runner_name}'

--- a/src/ucc_bench/main.py
+++ b/src/ucc_bench/main.py
@@ -71,6 +71,14 @@ def main() -> None:
         "--only_benchmark",
         help="Run only the specified benchmark.",
     )
+    parser.add_argument(
+        "--upstream_hash",
+        help="Hash of upstream commit of UCC being tested. This is used to track the version of UCC being benchmarked.",
+    )
+    parser.add_argument(
+        "--upstream_timestamp",
+        help="Timestamp of upstream commit of UCC being tested. This is used to track the version of UCC being benchmarked.",
+    )
 
     args = parser.parse_args()
 
@@ -105,6 +113,8 @@ def main() -> None:
             runner_specs=RunnerInfo.from_system(),
             runner_version=__version__,
             runner_args=sys.argv,
+            upstream_hash=args.upstream_hash,
+            upstream_timestamp=args.upstream_timestamp,
         ),
         results=benchmark_results,
     )

--- a/src/ucc_bench/results.py
+++ b/src/ucc_bench/results.py
@@ -35,6 +35,8 @@ class Metadata(BaseModel):
     runner_specs: RunnerInfo
     runner_version: str
     runner_args: List[str]
+    upstream_hash: Optional[str] = None
+    upstream_timestamp: Optional[datetime] = None
 
 
 class CompilerInfo(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -1654,8 +1654,8 @@ wheels = [
 
 [[package]]
 name = "ucc"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
+version = "0.4.4"
+source = { git = "https://github.com/unitaryfoundation/ucc?rev=65e6bdbfd1f30a015375e58c40b359d4a816ba5d#65e6bdbfd1f30a015375e58c40b359d4a816ba5d" }
 dependencies = [
     { name = "cirq-core" },
     { name = "ply" },
@@ -1663,10 +1663,6 @@ dependencies = [
     { name = "qbraid" },
     { name = "qiskit" },
     { name = "qiskit-qasm3-import" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/3b/d5de88056a7211d92f70df32386bd8423852d64325fe0ca6283a9e3e4483/ucc-0.4.3.tar.gz", hash = "sha256:918e0d404e0792b9b134c0ce1ed56a21554b655c207c9125b38b7957f61d2511", size = 17448 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/2a/224ec839e5a15899cee79a42a5c1c82d8f52a152ce2d2e4ef4beac221ffd/ucc-0.4.3-py3-none-any.whl", hash = "sha256:8267e50f3d45a01d836f072c1b57e6fe71f3063e68aa595d37fd3d6da201406c", size = 19386 },
 ]
 
 [[package]]
@@ -1702,7 +1698,7 @@ requires-dist = [
     { name = "qbraid", specifier = ">=0.9.4" },
     { name = "qiskit", specifier = ">=1.4.2" },
     { name = "qiskit-aer", specifier = ">=0.17.0" },
-    { name = "ucc", specifier = ">=0.4.3" },
+    { name = "ucc", git = "https://github.com/unitaryfoundation/ucc?rev=65e6bdbfd1f30a015375e58c40b359d4a816ba5d" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Add github action to run benchmarks on a push to main (including merge of PR).

Also add optional fields to the benchmark result metadata to include the hash/hash timestamp of the **version** of `ucc` that was used by `ucc-bench` at the time of the run.

This will fail until the benchmark runner is affiliated with this project.