### PR TITLE
Refactor PR comment actions to work with external contributions

### DIFF
--- a/.github/scripts/run_benchmarks_pr.sh
+++ b/.github/scripts/run_benchmarks_pr.sh
@@ -9,8 +9,8 @@ if [[ ! -f ".github/scripts/run_benchmarks_pr.sh" ]]; then
   exit 1
 fi
 
-if [ "$#" -ne 4 ]; then
-    echo "Usage: $0 <REPO_NAME> <RUNNER_LABEL> <SHA_OR_UCC_NEW_SHA> <PR_NUMBER>"
+if [ "$#" -ne 5 ]; then
+    echo "Usage: $0 <REPO_NAME> <RUNNER_LABEL> <SHA_OR_UCC_NEW_SHA> <PR_NUMBER> <COMMENT_FILE.json>"
     exit 1
 fi
 
@@ -18,6 +18,7 @@ REPO_NAME=$1 # the name of the repository (e.g., "ucc-bench" or "ucc")
 RUNNER_LABEL=$2 # e.g. ucc-benchmarks-8-core-U22.04
 SHA_OR_UCC_NEW_SHA=$3 # the SHA of the commit in ucc or ucc-bench to run
 PR_NUMBER=$4 # the pull request number to post the comment to
+JSON_FILE=$5
 
 if [[ "$REPO_NAME" == "ucc-bench" ]]; then
   IS_UCC_BENCH=true
@@ -86,22 +87,24 @@ echo "::endgroup::"
 # Post benchmark diff comment
 echo "::group::Post benchmark diff comment"
 if [[ "$IS_UCC_BENCH" == false ]]; then
-  uv run python .github/scripts/post_benchmark_diff_comment.py \
-  --repo "ucc" \
+  uv run python .github/scripts/benchmark_diff_comment.py \
+  prepare --repo "ucc" \
   --pr "$PR_NUMBER" \
   --root_dir ./results \
   --runner_name $RUNNER_LABEL \
   --sha_base $ANCESTOR_SHA \
   --sha_new "$SHA_NEW" \
   --sha_ucc_base "$UCC_BASE_SHA" \
-  --sha_ucc_new "$UCC_NEW_SHA"
+  --sha_ucc_new "$UCC_NEW_SHA" \
+  --output "$JSON_FILE"
 else
-  uv run python .github/scripts/post_benchmark_diff_comment.py \
-  --repo "ucc-bench" \
+  uv run python .github/scripts/benchmark_diff_comment.py \
+  prepare --repo "ucc-bench" \
   --pr "$PR_NUMBER" \
   --root_dir ./results \
   --runner_name $RUNNER_LABEL \
   --sha_base $ANCESTOR_SHA \
-  --sha_new "$SHA_NEW"
+  --sha_new "$SHA_NEW" \
+  --output "$JSON_FILE"
 fi
 echo "::endgroup::"

--- a/.github/workflows/run_benchmarks_pr_post.yml
+++ b/.github/workflows/run_benchmarks_pr_post.yml
@@ -1,0 +1,68 @@
+# After one of the `run_benchmarks_pr_ucc*yml` workflows completes, this
+# will dispatch to post the resulting comment back to the originating PR.
+# The triggering job will have saved the contents of the comment in a
+# comments.json build artifact file.
+#
+# We perform this is a separate step because this job needs elevated permissions
+# to post the comment, whereas the job to run the benchmarks runs contributed code
+# and shouldn't have access to such permissions.
+name: Post PR Benchmark Comparison comment
+
+on:
+  workflow_run:
+    workflows: ["Run ucc-bench PR Benchmark Comparison", "Run ucc-bench PR Benchmark Comparison"]
+    types: [completed]
+
+jobs:
+  post-benchmark-pr-comment:
+    runs-on: ubuntu-latest
+    steps:
+      # Prepare a token of Github App to post the comment
+      # Note the private key needs to be PKCS#8 format, so
+      # follow https://github.com/gr2m/universal-github-app-jwt?tab=readme-ov-file#converting-openssh-to-pkcs8
+      # to convert to another format before adding it as a secret
+      # Run this step first to fail fast
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.UCC_BENCH_APP_ID }}
+          private-key: ${{ secrets.UCC_BENCH_APP_PRIVATE_KEY }}
+          owner: unitaryfoundation
+          repositories: |
+            ucc-bench
+            ucc
+
+      # Get the repository as of the main branch; we only need the script to post the comment
+      # and intentionally do not want to get any non-reviewed code involved, since that code could
+      # attempt to leak/misuse secrets
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install python dependencies
+        run: uv sync --all-extras --all-groups
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: comment.json
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Post the comment
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: uv run python .github/scripts/benchmark_diff_comment.py post --input comment.json
+
+

--- a/.github/workflows/run_benchmarks_pr_ucc.yml
+++ b/.github/workflows/run_benchmarks_pr_ucc.yml
@@ -1,6 +1,10 @@
-# When triggered (by a PR in the ucc repo), run benchmarks and post a comment back detailing the results.
+# When triggered (by a PR in the ucc repo), run benchmarks and generates a comment detailing the results.
 # Unlike benchmarks on pushes to main, these results are not committed back to the repo.
 # The purpose here is to provide performance view before merging a PR.
+#
+# This job only runs and generates the comments. A subsequent run_benchmarks_pr_post will be
+# triggered to do the post. These are separate steps because this job is running 3rd party contributed
+# code, and should not have access to the secrets needed to post a PR comment.
 #
 # !!This workflow is triggered by PRs in the ucc repo and comments back to that repo.
 # !!For PRs to the ucc-bench repo, the there is a `run_benchmarks_pr.yml` workflow that
@@ -28,23 +32,6 @@ jobs:
       cancel-in-progress: true
 
     steps:
-
-      # Prepare a token of Github App to post the comment
-      # Note the private key needs to be PKCS#8 format, so
-      # follow https://github.com/gr2m/universal-github-app-jwt?tab=readme-ov-file#converting-openssh-to-pkcs8
-      # to convert to another format before adding it as a secret
-      # Run this step first to fail fast
-      - name: Generate token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.UCC_BENCH_APP_ID }}
-          private-key: ${{ secrets.UCC_BENCH_APP_PRIVATE_KEY }}
-          owner: unitaryfoundation
-          repositories: |
-            ucc-bench
-            ucc
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed to walk ancestor commits
@@ -59,7 +46,13 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Run benchmarks and post PR comment
+      - name: Run benchmarks and save PR comment as build artifact
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: bash .github/scripts/run_benchmarks_pr.sh ucc $RUNNER_LABEL ${{ github.event.client_payload.commit_hash }} ${{ github.event.client_payload.pr_number }}
+        run: bash .github/scripts/run_benchmarks_pr.sh ucc $RUNNER_LABEL ${{ github.event.client_payload.commit_hash }} ${{ github.event.client_payload.pr_number }} comment.json
+
+      - name: Save PR comment as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment.json
+          path: comment.json

--- a/.github/workflows/run_benchmarks_pr_ucc_bench.yml
+++ b/.github/workflows/run_benchmarks_pr_ucc_bench.yml
@@ -1,8 +1,12 @@
-# Run benchmarks on pull requests and post a comment back detailing the results.
+# Run benchmarks on pull requests and generate a comment to post back detailing the results.
 # Unlike benchmarks on pushes, these results are not committed back to the repo.
 # The purpose here is to provide performance view before merging a PR.
 # This will only be run if the PR has the label "preview-benchmark-results"
 # and will be skipped if the label is removed.
+#
+# This job only runs and generates the comments. A subsequent run_benchmarks_pr_post will be
+# triggered to do the post. These are separate steps because this job is running 3rd party contributed
+# code, and should not have access to the secrets needed to post a PR comment.
 #
 # !!This workflow is triggered by PRs in the ucc-bench repo. For PRs to the UCC
 # !!repo, the there is a another `run_benchmarks_pr_ucc.yml` workflow that is triggered
@@ -18,9 +22,6 @@ on:
       - labeled
       - unlabeled
 
-permissions:
-  pull-requests: write
-  contents: read
 # Set the runner name here for use in a later step, but also next to
 # the actual runs-on designation below so users know to change both together
 env:
@@ -36,23 +37,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      # Prepare a token of Github App to post the comment
-      # Note the private key needs to be PKCS#8 format, so
-      # follow https://github.com/gr2m/universal-github-app-jwt?tab=readme-ov-file#converting-openssh-to-pkcs8
-      # to convert to another format before adding it as a secret
-      # Run this step first to fail fast
-      - name: Generate token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.UCC_BENCH_APP_ID }}
-          private-key: ${{ secrets.UCC_BENCH_APP_PRIVATE_KEY }}
-          owner: unitaryfoundation
-          repositories: ucc-bench
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Needed to walk ancestor commits
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -63,7 +51,12 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Run benchmarks and post PR comment
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: bash .github/scripts/run_benchmarks_pr.sh ucc-bench $RUNNER_LABEL ${{ github.sha }} ${{ github.event.pull_request.number }}
+      - name: Run benchmarks and generate PR comment
+        run: bash .github/scripts/run_benchmarks_pr.sh ucc-bench $RUNNER_LABEL ${{ github.sha }} ${{ github.event.pull_request.number }} comment.json
+
+      - name: Save PR comment as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment.json
+          path: comment.json
+

--- a/results/README.md
+++ b/results/README.md
@@ -68,7 +68,8 @@ There are two related workflows, one for PRs to [`ucc`](../.github/workflows/run
 1. Upgrading the version of `ucc` if this is a PR to `ucc`
 2. Run the benchmarks on the updated code and commiting them to the ephemeral working branch
 3. Determining the hash of the baseline commit,
-4. Calling into a [python helper](../.github/scripts/post_benchmark_diff_comment.py) to diff the result files and post a comment to the PR.
+4. Calling into a [python helper](../.github/scripts/benchmark_diff_comment.py) to diff the result files and save the comment as markdown in a build step artifact
+5. A separate job is dispatched to do the final post. This job requires write permissions to post the comment to the PR, so it is intentionally separate from the prior steps, so that we are never running externally contributed code in a job that has access to secrets.
 
 The triggering workflow in `ucc` is defined here [here](https://github.com/unitaryfoundation/ucc/blob/main/.github/workflows/trigger-ucc-bench-pr.yml)
 


### PR DESCRIPTION
Resolves #48 by modifying the workflows for doing the PR benchmark comparison and comment. Currently, the flow will not run on code contributed from a fork for security reasons. To fix, this change separates the act of running the benchmarks and doing the diff (which doesn't require elevated permissions), from the act of posting the PR comment back (which does require elevated permissions). The concern is running any unreviewed code in a context with elevated permissions, as secrets or other actions could be taken in that code.

With this change, the first job runs the benchmarks, diffs results and saves the result as a json file in a github artifact. None of these require elevated permissions. The second job then reads the artifact and posts the comment the the PR (which does require elevated permissions). 

The benefit here is we will be able to run the preview benchmark workflow on a PR from a fork, although we will still need a maintainer to add the label. I had previously thought that was enough, but turned out just the fact its a fork restricted the permissions needed to post a comment.