### PR TITLE
Add+use GHZ and uniform superposition state observables

### DIFF
--- a/benchmarks/compilation_benchmarks.toml
+++ b/benchmarks/compilation_benchmarks.toml
@@ -49,7 +49,7 @@ qasm_file = "circuits/benchpress/square_heisenberg_N100_basis_rz_rx_ry_cx.qasm"
 
 [[benchmarks]]
 id="prep_select"
-description = "GHZ state preparation"
+description = "Prepare and grover select all 1s state"
 qasm_file = "circuits/ucc/prep_select_N25_ghz_basis_rz_rx_ry_h_cx.qasm"
 
 [[benchmarks]]

--- a/benchmarks/layout_benchmarks.toml
+++ b/benchmarks/layout_benchmarks.toml
@@ -41,7 +41,7 @@ qasm_file = "circuits/benchpress/square_heisenberg_N9_basis_rz_rx_ry_cx.qasm"
 # UCC crashing with out of bounds on this (ucc-default isn't)
 # [[benchmarks]]
 # id="prep_select"
-# description = "GHZ state preparation"
+# description = "Prepare and select all 1s state""
 # qasm_file = "circuits/ucc/prep_select_N10_ghz_basis_rz_rx_ry_h_cx.qasm"
 
 [[benchmarks]]

--- a/benchmarks/simulation_benchmarks.toml
+++ b/benchmarks/simulation_benchmarks.toml
@@ -49,7 +49,7 @@ simulate.measurement = "heavy_output"
 id = "qft"
 description = "Quantum Fourier Transform"
 qasm_file = "circuits/benchpress/qft_N010_basis_rz_rx_ry_cx.qasm"
-simulate.measurement = "computational_basis"
+simulate.measurement = "uniform_superposition_projector"
 
 [[benchmarks]]
 id="square_heisenberg"
@@ -59,9 +59,9 @@ simulate.measurement = "hamlib_heisenberg_pbc-qubitnodes_Lx_Ly_h-0.5"
 
 [[benchmarks]]
 id="prep_select"
-description = "GHZ state preparation"
+description = "Prepare and grover select all 1s state"
 qasm_file = "circuits/ucc/prep_select_N10_ghz_basis_rz_rx_ry_h_cx.qasm"
-simulate.measurement = "computational_basis"
+simulate.measurement = "prep_select_all_ones"
 
 [[benchmarks]]
 id="qcnn"

--- a/src/ucc_bench/simulation/observables.py
+++ b/src/ucc_bench/simulation/observables.py
@@ -86,6 +86,31 @@ def generate_computational_basis_observable(
     return Operator.from_label("Z" * num_qubits)
 
 
+@register.observable("ghz_state_projector")
+def generate_ghz_state_projector(num_qubits: int) -> Operator:
+    """Generates the projector for the GHZ state |0...0> + |1...1>."""
+    ghz_state = Statevector.from_label("0" * num_qubits) + Statevector.from_label(
+        "1" * num_qubits
+    )
+    ghz_state /= np.sqrt(2)
+    return ghz_state.to_operator()
+
+
+@register.observable("uniform_superposition_projector")
+def generate_uniform_superposition_projector(num_qubits: int) -> Operator:
+    """Generates the projector for the uniform superposition state."""
+    raw_vec = np.ones(2**num_qubits) / np.sqrt(2**num_qubits)
+    return Statevector(raw_vec).to_operator()
+
+
+@register.observable("prep_select_all_ones")
+def generate_prep_select_all_ones_observable(num_qubits: int) -> Operator:
+    """Generate a projector that is uniform superposition over computational basis but with (-1) phase on the all ones"""
+    raw_vec = np.ones(2**num_qubits) / np.sqrt(2**num_qubits)
+    raw_vec[-1] *= -1
+    return Statevector(raw_vec).to_operator()
+
+
 def lattice_to_qubit_mapping(nnodes):
     """Generate qubit mapping for the square Heisenberg problem Hamiltonian."""
     lattice = np.arange(nnodes * nnodes).reshape(

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -4,6 +4,9 @@ from ucc_bench.simulation.noise_models import get_n_qubit_gateset
 from ucc_bench.simulation.observables import (
     generate_qcnn_observable,
     generate_computational_basis_observable,
+    generate_ghz_state_projector,
+    generate_uniform_superposition_projector,
+    generate_prep_select_all_ones_observable,
 )
 
 
@@ -63,3 +66,24 @@ def test_generate_qcnn_observable():
     assert generate_qcnn_observable(6) == SparsePauliOp(
         ["ZXZIII", "IZXZII", "IIZXZI", "IIIZXZ"]
     )
+
+
+def test_generate_ghz_state_projector():
+    expected = (
+        1 / 2 * Operator([[1, 0, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 1]])
+    )
+    assert generate_ghz_state_projector(2) == expected
+
+
+def test_generate_uniform_superposition_projector():
+    expected = (
+        1 / 4 * Operator([[1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1], [1, 1, 1, 1]])
+    )
+    assert generate_uniform_superposition_projector(2) == expected
+
+
+def test_generate_prep_select_all_ones():
+    expected = (
+        1 / 4 * Operator([[1, 1, 1, -1], [1, 1, 1, -1], [1, 1, 1, -1], [-1, -1, -1, 1]])
+    )
+    assert generate_prep_select_all_ones_observable(2) == expected


### PR DESCRIPTION
Resolves #91 

Add GHZ and uniform superposition state observables and use the latter for prep_select and qft circuits in simulation benchmarks.