### PR TITLE
Use qiskit.backend to represent target device

### DIFF
--- a/src/ucc_bench/compilers/base_compiler.py
+++ b/src/ucc_bench/compilers/base_compiler.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar, Optional
 from qbraid import transpile
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 
 # Define a generic type variable for a circuit, that concrete implementations
 # will define for each library type
@@ -51,7 +51,7 @@ class BaseCompiler(ABC, Generic[CircuitType]):
 
     @abstractmethod
     def compile(
-        self, circuit: CircuitType, target_device: Optional[Target] = None
+        self, circuit: CircuitType, target_device: Optional[Backend] = None
     ) -> CircuitType:
         """Compile the given circuit"""
         pass

--- a/src/ucc_bench/compilers/cirq_compiler.py
+++ b/src/ucc_bench/compilers/cirq_compiler.py
@@ -3,7 +3,7 @@ import cirq
 from typing import List, Optional
 import warnings
 from ..registry import register
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 
 
 class BenchmarkTargetGateset(cirq.TwoQubitCompilationTargetGateset):
@@ -106,7 +106,7 @@ class CirqCompiler(BaseCompiler[cirq.Circuit]):
         return cirq.__version__
 
     def compile(
-        self, circuit: cirq.Circuit, target_device: Optional[Target] = None
+        self, circuit: cirq.Circuit, target_device: Optional[Backend] = None
     ) -> cirq.Circuit:
         if target_device is not None:
             raise ValueError("Cirq benchmark does not support target devices yet.")

--- a/src/ucc_bench/compilers/pyqpanda3_compiler.py
+++ b/src/ucc_bench/compilers/pyqpanda3_compiler.py
@@ -1,7 +1,7 @@
 from .base_compiler import BaseCompiler
 from ..registry import register
 from typing import Optional
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 
 try:
     from pyqpanda3 import __version__ as pyqpanda_version
@@ -42,7 +42,7 @@ if PYQPANDA3_AVAILABLE:
             return convert_qprog_to_qasm(circuit)
 
         def compile(
-            self, circuit: QProg, target_device: Optional[Target] = None
+            self, circuit: QProg, target_device: Optional[Backend] = None
         ) -> QProg:
             if target_device is not None:
                 raise ValueError(

--- a/src/ucc_bench/compilers/pytket_compiler.py
+++ b/src/ucc_bench/compilers/pytket_compiler.py
@@ -11,7 +11,7 @@ from pytket import Circuit as PytketCircuit
 from qbraid import transpile
 from ..registry import register
 from typing import Optional
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 
 
 @register.compiler("pytket-peep")
@@ -31,7 +31,7 @@ class PytketPeepCompiler(BaseCompiler[PytketCircuit]):
         return transpile(qasm, "pytket")
 
     def compile(
-        self, circuit: PytketCircuit, target_device: Optional[Target] = None
+        self, circuit: PytketCircuit, target_device: Optional[Backend] = None
     ) -> PytketCircuit:
         if target_device is not None:
             raise ValueError("Pytket benchmark does not support target devices yet.")

--- a/src/ucc_bench/compilers/qiskit_compiler.py
+++ b/src/ucc_bench/compilers/qiskit_compiler.py
@@ -4,7 +4,7 @@ from qiskit import (
     transpile as qiskit_transpile,
     __version__ as qiskit_version,
 )
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 from typing import Optional
 from qbraid import transpile
 
@@ -28,14 +28,18 @@ class QiskitCompiler(BaseCompiler[QuantumCircuit]):
         return transpile(qasm, "qiskit")
 
     def compile(
-        self, circuit: QuantumCircuit, target_device: Optional[Target] = None
+        self, circuit: QuantumCircuit, target_device: Optional[Backend] = None
     ) -> QuantumCircuit:
-        return qiskit_transpile(
-            circuit,
-            optimization_level=3,
-            basis_gates=["rz", "rx", "ry", "h", "cx"],
-            coupling_map=target_device.build_coupling_map() if target_device else None,
-        )
+        if target_device is not None:
+            return qiskit_transpile(
+                circuit,
+                optimization_level=3,
+                backend=target_device,
+            )
+        else:
+            return qiskit_transpile(
+                circuit, optimization_level=3, basis_gates=["rz", "rx", "ry", "h", "cx"]
+            )
 
     def count_multi_qubit_gates(self, circuit: QuantumCircuit) -> int:
         return circuit.num_nonlocal_gates()

--- a/src/ucc_bench/compilers/ucc_compiler.py
+++ b/src/ucc_bench/compilers/ucc_compiler.py
@@ -5,7 +5,7 @@ from ucc import compile
 # UCC uses qiskit internally
 ## TODO: ucc should expose a circuit type vs. assuming always qiskit?
 from qiskit import QuantumCircuit
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 from typing import Optional
 from qbraid import transpile
 from ..registry import register
@@ -26,13 +26,15 @@ class UCCCompiler(BaseCompiler[QuantumCircuit]):
         return transpile(qasm, "qiskit")
 
     def compile(
-        self, circuit: QuantumCircuit, target_device: Optional[Target] = None
+        self, circuit: QuantumCircuit, target_device: Optional[Backend] = None
     ) -> QuantumCircuit:
-        return compile(
-            circuit,
-            target_gateset={"rx", "ry", "rz", "h", "cx"},
-            target_device=target_device,
-        )
+        if target_device is not None:
+            return compile(circuit, target_backend=target_device)
+        else:
+            return compile(
+                circuit,
+                target_gateset={"rx", "ry", "rz", "h", "cx"},
+            )
 
     def count_multi_qubit_gates(self, circuit: QuantumCircuit) -> int:
         return circuit.num_nonlocal_gates()

--- a/src/ucc_bench/registry.py
+++ b/src/ucc_bench/registry.py
@@ -2,7 +2,7 @@ from typing import Callable
 from qiskit.quantum_info import Operator
 from qiskit import QuantumCircuit
 from qiskit_aer.noise import NoiseModel
-from qiskit.transpiler import Target
+from qiskit.providers import Backend
 
 # To avoid circular imports between this module and compilers,
 # only import the BaseCompiler class when type checking.
@@ -113,7 +113,7 @@ class Registry:
     ) -> Callable[[QuantumCircuit, QuantumCircuit, NoiseModel], float]:
         return self._output_metric[id]
 
-    def add_target_device(self, id: str, t: Target):
+    def add_target_device(self, id: str, t: Backend):
         """
         Add a given target device to the registry associated with the given id.
         """
@@ -126,7 +126,7 @@ class Registry:
     def has_target_device(self, id: str) -> bool:
         return id in self._target_devices
 
-    def get_target_device(self, id: str) -> Target:
+    def get_target_device(self, id: str) -> Backend:
         return self._target_devices[id]
 
 

--- a/src/ucc_bench/target_devices.py
+++ b/src/ucc_bench/target_devices.py
@@ -3,4 +3,4 @@ from .registry import register
 from qiskit_ibm_runtime.fake_provider import FakeProviderForBackendV2
 
 for device in FakeProviderForBackendV2().backends():
-    register.add_target_device("ibm_" + device.name, device.target)
+    register.add_target_device("ibm_" + device.name, device)


### PR DESCRIPTION
To correspond with updates in https://github.com/unitaryfoundation/ucc/pull/541, this changes the interface to use qiskit Backends to represent target devices. I decided to keep the name "target_device" the same in the command line and in the historical benchmark result data where the code uses that term. I like this a bit better than Backend anyway, as these benchmarks don't care about the submission and job results aspects that Qiskit Backend encompasses.