### PR TITLE
Pin pyqpanda3 version:

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "ruff>=0.11.2",
 ]
 pyqpanda3 = [
-    "pyqpanda3>=0.2.2",
+    "pyqpanda3<0.3.2", #pin to version that was failing circuit equivalence on OSX (but not linux)
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1396,7 +1396,7 @@ wheels = [
 
 [[package]]
 name = "pyqpanda3"
-version = "0.3.2"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cython" },
@@ -1408,14 +1408,12 @@ dependencies = [
     { name = "setuptools" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/8a/842d2fa501ba0952c0b1a59f18300d47828bce4bbbf675445ef0c0b04935/pyqpanda3-0.3.2-cp312-cp312-macosx_10_11_x86_64.whl", hash = "sha256:f1979994f55835d93bba97e84692bf2ff9ee4ee86073a4a64187c54e09d9c687", size = 18824756, upload-time = "2025-10-14T06:44:47.445Z" },
-    { url = "https://files.pythonhosted.org/packages/70/3d/d0fba915f95ec46cef5ec21179d5d78defae8fb0bf46d29e50d2a339cb27/pyqpanda3-0.3.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:84ccc34b724a6f26283be29c2b8dbd343a2d3f130d683bb718d12f0e89668a21", size = 16120590, upload-time = "2025-08-15T09:45:17.221Z" },
-    { url = "https://files.pythonhosted.org/packages/92/7a/fae9fba4a38cc338959913051f90e0ce180afbfcaadf00efd27ce861f1c4/pyqpanda3-0.3.2-cp312-none-manylinux1_x86_64.whl", hash = "sha256:61d02d2f78c383d43df5e3790bf363ab28e69ec5e1028392731685e0248d482c", size = 35354278, upload-time = "2025-08-15T09:47:14.649Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/5a/8869dc4153ee06a625bf1030b12988a14aa2d7f3fa57196afaf00a6a3b58/pyqpanda3-0.3.2-cp312-none-win_amd64.whl", hash = "sha256:58025ba1a48eae24928ec405dc6c62692ed491e8aada0bcb40ac2e36807c65be", size = 21640208, upload-time = "2025-08-15T09:48:20.013Z" },
-    { url = "https://files.pythonhosted.org/packages/39/18/747675184e2927fe70911a856d9ce56d1c81c52f7d65c176b1e0827e31c4/pyqpanda3-0.3.2-cp313-cp313-macosx_10_11_x86_64.whl", hash = "sha256:06d4d37376adc847904d3118478770d3242322389d0bad565a705712727f6337", size = 18825346, upload-time = "2025-10-14T06:45:05.679Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/21/b403bd295391e2803dcf9215b1c58278f12dbae5aa4156916f2e04a09099/pyqpanda3-0.3.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:7a4bbff72b624760c84bd00c7df76b2c195be271b66585c0cd3c24f425192dab", size = 16121158, upload-time = "2025-08-15T09:49:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/73/46/6fce2ebd7b6d5e3738e9934a05768ba87a19b574dcdf99b464ac33d5ad30/pyqpanda3-0.3.2-cp313-none-manylinux1_x86_64.whl", hash = "sha256:5b22dec1c3fea8d08091123822c8487e5dcaf5136ed4533c34902629b6e4770b", size = 35355265, upload-time = "2025-08-15T09:51:08.171Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/92/597c7af9876e2300e6127f48f285f5440c17502f910442355636d38ca5e8/pyqpanda3-0.3.2-cp313-none-win_amd64.whl", hash = "sha256:680222a89924e62ed6d44433e2be65e1f0dd353f7326c3fb6c304fc1d8327cb3", size = 21640465, upload-time = "2025-08-15T09:52:23.972Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b9/1f79127ecc1d66cd1908ab3e400824b6b11246fdbfdae4198e10771b119e/pyqpanda3-0.3.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:d2da1e397babc238de69ed9448ff3f275321a76ce7b8e98f9bbb0929ebe525d6", size = 14592843, upload-time = "2025-06-13T06:40:35.539Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ee/be0116b7e773404e707404731cd3040858609d1c3238ad9a3526a23ad0b4/pyqpanda3-0.3.1-cp312-none-manylinux1_x86_64.whl", hash = "sha256:d55912d3e1cab736b43b12b5997e7dcfce2d98c1251846032341da4925c13870", size = 22816740, upload-time = "2025-06-13T06:41:39.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/aa/09edc834879563b9cac300a4efad07269aef631c5a39675c278c88bfd62c/pyqpanda3-0.3.1-cp312-none-win_amd64.whl", hash = "sha256:fb08be7bed84848729c772a3962f6048960a516e08aa64b2b17df9dc52e04ad1", size = 11505002, upload-time = "2025-06-13T06:42:08.088Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/748d68005be5a0d80031e810ff0b5bf616c6222206036a481e933e47080f/pyqpanda3-0.3.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:c3b67515956aa4dc8a5c7a9df2ac81119270edc25ce8ced787fe79dfe17906a1", size = 14593208, upload-time = "2025-06-13T06:42:43.4Z" },
+    { url = "https://files.pythonhosted.org/packages/15/99/241248edc55805fcee2b35b0b7bacf46e404bede7ea76279851c5d2caf23/pyqpanda3-0.3.1-cp313-none-manylinux1_x86_64.whl", hash = "sha256:6ad18226bb405cc69e3dc31beb1047c6dbedc5b28bbc7fb815473b678d8e81b4", size = 22818948, upload-time = "2025-06-13T06:43:45.335Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/86/8e08711bb1345906fe32eefbd43737b6a6afaaa5613a3b023641849b5e69/pyqpanda3-0.3.1-cp313-none-win_amd64.whl", hash = "sha256:6657c93b856cb8672bfdbbe763c9374de4bb851ff00e6bc2cae967725ad52d8a", size = 11505136, upload-time = "2025-06-13T06:44:17.043Z" },
 ]
 
 [[package]]
@@ -2021,7 +2019,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.2" },
 ]
-pyqpanda3 = [{ name = "pyqpanda3", specifier = ">=0.2.2" }]
+pyqpanda3 = [{ name = "pyqpanda3", specifier = "<0.3.2" }]
 
 [[package]]
 name = "urllib3"


### PR DESCRIPTION
Pin pyqpanda3 to the version before it started failing logical equivalance checks on mac. It still passes linux, but keeping consistent for now and can revisit with future pyqpanda3 versions.